### PR TITLE
Implement coroutine dispatcher

### DIFF
--- a/app/src/main/java/org/n27/nutshell/common/data/api/FirebaseApi.kt
+++ b/app/src/main/java/org/n27/nutshell/common/data/api/FirebaseApi.kt
@@ -1,8 +1,10 @@
 package org.n27.nutshell.common.data.api
 
+import android.util.Log
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.GenericTypeIndicator
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withTimeout
 import org.n27.nutshell.common.Constants.EMPTY_RESPONSE_FROM_FIREBASE
@@ -34,7 +36,9 @@ class FirebaseApi @Inject constructor(
         failure(Throwable(NO_INTERNET_CONNECTION))
     } else {
         runCatching {
-            withTimeout(10000) { firebaseDatabase.getReference(key).get().await() }
+            withTimeout(10000) {
+                firebaseDatabase.getReference(key).get().await()
+            }
         }
     }
 }

--- a/app/src/main/java/org/n27/nutshell/common/data/api/FirebaseApi.kt
+++ b/app/src/main/java/org/n27/nutshell/common/data/api/FirebaseApi.kt
@@ -1,10 +1,8 @@
 package org.n27.nutshell.common.data.api
 
-import android.util.Log
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.GenericTypeIndicator
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withTimeout
 import org.n27.nutshell.common.Constants.EMPTY_RESPONSE_FROM_FIREBASE

--- a/app/src/main/java/org/n27/nutshell/common/data/api/FirebaseApi.kt
+++ b/app/src/main/java/org/n27/nutshell/common/data/api/FirebaseApi.kt
@@ -34,9 +34,7 @@ class FirebaseApi @Inject constructor(
         failure(Throwable(NO_INTERNET_CONNECTION))
     } else {
         runCatching {
-            withTimeout(10000) {
-                firebaseDatabase.getReference(key).get().await()
-            }
+            withTimeout(10000) { firebaseDatabase.getReference(key).get().await() }
         }
     }
 }

--- a/app/src/main/java/org/n27/nutshell/common/dispatcher/CoroutineDispatcherProvider.kt
+++ b/app/src/main/java/org/n27/nutshell/common/dispatcher/CoroutineDispatcherProvider.kt
@@ -1,0 +1,10 @@
+package org.n27.nutshell.common.dispatcher
+
+import kotlinx.coroutines.CoroutineDispatcher
+
+interface CoroutineDispatcherProvider {
+    val main: CoroutineDispatcher
+    val default: CoroutineDispatcher
+    val io: CoroutineDispatcher
+    val unconfined: CoroutineDispatcher
+}

--- a/app/src/main/java/org/n27/nutshell/common/dispatcher/DefaultCoroutineDispatcherProvider.kt
+++ b/app/src/main/java/org/n27/nutshell/common/dispatcher/DefaultCoroutineDispatcherProvider.kt
@@ -1,0 +1,12 @@
+package org.n27.nutshell.common.dispatcher
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Inject
+
+class DefaultCoroutineDispatcherProvider @Inject constructor() : CoroutineDispatcherProvider {
+    override val main: CoroutineDispatcher = Dispatchers.Main
+    override val default: CoroutineDispatcher = Dispatchers.Default
+    override val io: CoroutineDispatcher = Dispatchers.IO
+    override val unconfined: CoroutineDispatcher = Dispatchers.Unconfined
+}

--- a/app/src/main/java/org/n27/nutshell/common/presentation/di/PresentationModule.kt
+++ b/app/src/main/java/org/n27/nutshell/common/presentation/di/PresentationModule.kt
@@ -4,9 +4,12 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.crashlytics.ktx.crashlytics
+import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.ktx.Firebase
 import dagger.Module
 import dagger.Provides
+import org.n27.nutshell.common.dispatcher.CoroutineDispatcherProvider
+import org.n27.nutshell.common.dispatcher.DefaultCoroutineDispatcherProvider
 import javax.inject.Singleton
 
 @Module
@@ -19,4 +22,8 @@ class PresentationModule {
     @Provides
     @Singleton
     fun provideFirebaseAnalytics(): FirebaseAnalytics = Firebase.analytics
+
+    @Provides
+    @Singleton
+    fun provideCoroutineDispatcherProvider(): CoroutineDispatcherProvider = DefaultCoroutineDispatcherProvider()
 }

--- a/app/src/main/java/org/n27/nutshell/common/presentation/di/PresentationModule.kt
+++ b/app/src/main/java/org/n27/nutshell/common/presentation/di/PresentationModule.kt
@@ -4,7 +4,6 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.crashlytics.ktx.crashlytics
-import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.ktx.Firebase
 import dagger.Module
 import dagger.Provides

--- a/app/src/main/java/org/n27/nutshell/common/presentation/tracking/Tracker.kt
+++ b/app/src/main/java/org/n27/nutshell/common/presentation/tracking/Tracker.kt
@@ -1,8 +1,12 @@
 package org.n27.nutshell.common.presentation.tracking
 
+import android.util.Log
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 
 open class Tracker(private val crashlytics: FirebaseCrashlytics) {
 
-    fun trackError(throwable: Throwable) { crashlytics.recordException(throwable) }
+    fun trackError(throwable: Throwable) {
+        crashlytics.recordException(throwable)
+        Log.e("Error", throwable.message ?: "Error")
+    }
 }

--- a/app/src/main/java/org/n27/nutshell/detail/presentation/DetailViewModel.kt
+++ b/app/src/main/java/org/n27/nutshell/detail/presentation/DetailViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.n27.nutshell.common.Constants.EMPTY_LIST
 import org.n27.nutshell.common.data.repository.NutshellRepositoryImpl
+import org.n27.nutshell.common.dispatcher.CoroutineDispatcherProvider
 import org.n27.nutshell.common.presentation.mapping.toError
 import org.n27.nutshell.detail.domain.model.Detail
 import org.n27.nutshell.detail.presentation.entities.DetailAction
@@ -33,7 +34,8 @@ import org.n27.nutshell.detail.presentation.mapping.toUiState
 class DetailViewModel @AssistedInject constructor(
     @Assisted private val key: String,
     private val repository: NutshellRepositoryImpl,
-    private val tracker: DetailTracker
+    private val tracker: DetailTracker,
+    private val coroutineDispatcher: CoroutineDispatcherProvider,
 ) : ViewModel() {
 
     private val viewModelState = MutableStateFlow(DetailViewModelState())
@@ -87,7 +89,7 @@ class DetailViewModel @AssistedInject constructor(
     }
 
     private fun getDetail() {
-        viewModelScope.launch {
+        viewModelScope.launch(coroutineDispatcher.default) {
 
             viewModelState.update { it.copy(isLoading = true) }
 

--- a/app/src/main/java/org/n27/nutshell/topics/presentation/TopicsViewModel.kt
+++ b/app/src/main/java/org/n27/nutshell/topics/presentation/TopicsViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import org.n27.nutshell.common.data.repository.NutshellRepositoryImpl
+import org.n27.nutshell.common.dispatcher.CoroutineDispatcherProvider
 import org.n27.nutshell.common.presentation.mapping.toError
 import org.n27.nutshell.topics.presentation.entities.TopicsAction
 import org.n27.nutshell.topics.presentation.entities.TopicsAction.NextButtonClicked
@@ -24,7 +25,8 @@ import javax.inject.Inject
 
 class TopicsViewModel @Inject constructor(
     private val repository: NutshellRepositoryImpl,
-    private val tracker: TopicsTracker
+    private val tracker: TopicsTracker,
+    private val coroutineDispatcher: CoroutineDispatcherProvider,
 ) : ViewModel() {
 
     private val state = MutableStateFlow<TopicsUiState>(Loading)
@@ -53,7 +55,7 @@ class TopicsViewModel @Inject constructor(
     }
 
     private fun getTopics() {
-        viewModelScope.launch {
+        viewModelScope.launch(coroutineDispatcher.default) {
             state.emit(Loading)
 
             repository.getTopics()

--- a/app/src/test/java/org/n27/nutshell/common/dispatcher/TestDispatcherProvider.kt
+++ b/app/src/test/java/org/n27/nutshell/common/dispatcher/TestDispatcherProvider.kt
@@ -1,0 +1,12 @@
+package org.n27.nutshell.common.dispatcher
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestDispatcher
+
+class TestDispatcherProvider(testDispatcher: TestDispatcher) : CoroutineDispatcherProvider {
+    override val main: CoroutineDispatcher = testDispatcher
+    override val default: CoroutineDispatcher = testDispatcher
+    override val io: CoroutineDispatcher = testDispatcher
+    override val unconfined: CoroutineDispatcher = testDispatcher
+}

--- a/app/src/test/java/org/n27/nutshell/common/dispatcher/TestDispatcherProvider.kt
+++ b/app/src/test/java/org/n27/nutshell/common/dispatcher/TestDispatcherProvider.kt
@@ -1,7 +1,6 @@
 package org.n27.nutshell.common.dispatcher
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.TestDispatcher
 
 class TestDispatcherProvider(testDispatcher: TestDispatcher) : CoroutineDispatcherProvider {

--- a/app/src/test/java/org/n27/nutshell/detail/presentation/DetailViewModelTest.kt
+++ b/app/src/test/java/org/n27/nutshell/detail/presentation/DetailViewModelTest.kt
@@ -9,11 +9,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlinx.coroutines.test.TestScope
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.anyString

--- a/app/src/test/java/org/n27/nutshell/detail/presentation/DetailViewModelTest.kt
+++ b/app/src/test/java/org/n27/nutshell/detail/presentation/DetailViewModelTest.kt
@@ -13,12 +13,14 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.TestScope
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.n27.nutshell.common.data.repository.NutshellRepositoryImpl
+import org.n27.nutshell.common.dispatcher.TestDispatcherProvider
 import org.n27.nutshell.detail.presentation.entities.DetailAction.BackClicked
 import org.n27.nutshell.detail.presentation.entities.DetailAction.GetDetail
 import org.n27.nutshell.detail.presentation.entities.DetailAction.InfoClicked
@@ -153,7 +155,7 @@ internal class DetailViewModelTest {
         observer.close()
     }
 
-    private fun getViewModel() = DetailViewModel(KEY, repository, tracker)
+    private fun TestScope.getViewModel() = DetailViewModel(KEY, repository, tracker, TestDispatcherProvider(StandardTestDispatcher(testScheduler)))
 
     private companion object {
         private const val KEY = "taxes"

--- a/app/src/test/java/org/n27/nutshell/detail/presentation/DetailViewModelTest.kt
+++ b/app/src/test/java/org/n27/nutshell/detail/presentation/DetailViewModelTest.kt
@@ -46,7 +46,6 @@ internal class DetailViewModelTest {
         val expected = getHasContent()
         val viewModel = getViewModel()
         val observer = viewModel.uiState.test(this + UnconfinedTestDispatcher(testScheduler))
-
         `when`(repository.getDetail(anyString())).thenReturn(success(getDetail()))
 
         viewModel.handleAction(GetDetail)
@@ -61,7 +60,6 @@ internal class DetailViewModelTest {
         val expected = getHasContent()
         val viewModel = getViewModel()
         val observer = viewModel.uiState.test(this + UnconfinedTestDispatcher(testScheduler))
-
         `when`(repository.getDetail(anyString())).thenReturn(success(getDetail()))
 
         viewModel.handleAction(RetryClicked)
@@ -106,16 +104,15 @@ internal class DetailViewModelTest {
                 value = "54"
             )
         )
-
         `when`(repository.getDetail(anyString())).thenReturn(success(getDetail()))
-
         viewModel.handleAction(GetDetail)
         runCurrent()
+        observer.reset()
 
         viewModel.handleAction(NavItemClicked(1, "Income"))
         runCurrent()
 
-        observer.assertValues(getNoContent(), getHasContent(), expected)
+        observer.assertValues(expected)
         observer.close()
     }
 
@@ -127,7 +124,6 @@ internal class DetailViewModelTest {
             isLoading = false,
             error = getError()
         )
-
         `when`(repository.getDetail(anyString())).thenReturn(failure(Throwable()))
 
         viewModel.handleAction(GetDetail)
@@ -145,7 +141,6 @@ internal class DetailViewModelTest {
             isLoading = false,
             error = getError()
         )
-
         `when`(repository.getDetail(anyString())).thenReturn(success(getDetail(tabs = listOf())))
 
         viewModel.handleAction(GetDetail)
@@ -155,7 +150,12 @@ internal class DetailViewModelTest {
         observer.close()
     }
 
-    private fun TestScope.getViewModel() = DetailViewModel(KEY, repository, tracker, TestDispatcherProvider(StandardTestDispatcher(testScheduler)))
+    private fun TestScope.getViewModel() = DetailViewModel(
+        key = KEY,
+        repository = repository,
+        tracker = tracker,
+        coroutineDispatcher = TestDispatcherProvider(StandardTestDispatcher(testScheduler)),
+    )
 
     private companion object {
         private const val KEY = "taxes"

--- a/app/src/test/java/org/n27/nutshell/topics/presentation/TopicsViewModelTest.kt
+++ b/app/src/test/java/org/n27/nutshell/topics/presentation/TopicsViewModelTest.kt
@@ -40,7 +40,6 @@ internal class TopicsViewModelTest {
         val expected = getTopicsContent()
         val viewModel = getViewModel()
         val observer = viewModel.uiState.test(this + UnconfinedTestDispatcher(testScheduler))
-
         `when`(repository.getTopics()).thenReturn(success(getTopics()))
 
         runCurrent()
@@ -54,7 +53,6 @@ internal class TopicsViewModelTest {
         val expected = getTopicsContent()
         val viewModel = getViewModel()
         val observer = viewModel.uiState.test(this + UnconfinedTestDispatcher(testScheduler))
-
         `when`(repository.getTopics()).thenReturn(success(getTopics()))
 
         viewModel.handleAction(RetryButtonClicked)
@@ -68,7 +66,6 @@ internal class TopicsViewModelTest {
     fun `should emit go to next screen when next button clicked`() = runTest {
         val viewModel = getViewModel()
         val observer = viewModel.viewEvent.test(this + UnconfinedTestDispatcher(testScheduler))
-
         `when`(repository.getTopics()).thenReturn(success(getTopics()))
 
         viewModel.handleAction(NextButtonClicked(KEY, TITLE))
@@ -83,7 +80,6 @@ internal class TopicsViewModelTest {
         val expected = getTopicsError()
         val viewModel = getViewModel()
         val observer = viewModel.uiState.test(this + UnconfinedTestDispatcher(testScheduler))
-
         `when`(repository.getTopics()).thenReturn(failure(Throwable()))
 
         runCurrent()
@@ -92,7 +88,11 @@ internal class TopicsViewModelTest {
         observer.close()
     }
 
-    private fun TestScope.getViewModel() = TopicsViewModel(repository, tracker, TestDispatcherProvider(StandardTestDispatcher(testScheduler)))
+    private fun TestScope.getViewModel() = TopicsViewModel(
+        repository = repository,
+        tracker = tracker,
+        coroutineDispatcher = TestDispatcherProvider(StandardTestDispatcher(testScheduler)),
+    )
 
     private companion object {
         private const val KEY = "taxes"

--- a/app/src/test/java/org/n27/nutshell/topics/presentation/TopicsViewModelTest.kt
+++ b/app/src/test/java/org/n27/nutshell/topics/presentation/TopicsViewModelTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -16,6 +17,7 @@ import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.n27.nutshell.common.data.repository.NutshellRepositoryImpl
+import org.n27.nutshell.common.dispatcher.TestDispatcherProvider
 import org.n27.nutshell.topics.presentation.entities.TopicsAction.NextButtonClicked
 import org.n27.nutshell.topics.presentation.entities.TopicsAction.RetryButtonClicked
 import org.n27.nutshell.topics.presentation.entities.TopicsEvent.GoToNextScreen
@@ -90,7 +92,7 @@ internal class TopicsViewModelTest {
         observer.close()
     }
 
-    private fun getViewModel() = TopicsViewModel(repository, tracker)
+    private fun TestScope.getViewModel() = TopicsViewModel(repository, tracker, TestDispatcherProvider(StandardTestDispatcher(testScheduler)))
 
     private companion object {
         private const val KEY = "taxes"

--- a/app/src/test/java/org/n27/nutshell/utils/FlowTestObserver.kt
+++ b/app/src/test/java/org/n27/nutshell/utils/FlowTestObserver.kt
@@ -24,5 +24,7 @@ class FlowTestObserver<T>(scope: CoroutineScope, flow: Flow<T>) : Closeable {
         return this
     }
 
+    fun reset() { values.clear() }
+
     override fun close() = job.cancel()
 }


### PR DESCRIPTION
- Implement `CoroutineDispatcher` to avoid using the main thread on the `ViewModel`. Using `Dispatchers.Default` instead.
- Log errors locally.
- Implement `observer.reset()` to ease testing.